### PR TITLE
Disable setuptools_scm for NGLS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 # AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-requires = ["setuptools>=46.1.0,<50", "setuptools_scm[toml]>=5", "wheel"]
+requires = ["setuptools>=46.1.0,<50", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools_scm]
+#[tool.setuptools_scm]
 # See configuration details in https://github.com/pypa/setuptools_scm
-version_scheme = "no-guess-dev"
+#version_scheme = "no-guess-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,3 @@
 # AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
 requires = ["setuptools>=46.1.0,<50", "wheel"]
 build-backend = "setuptools.build_meta"
-
-#[tool.setuptools_scm]
-# See configuration details in https://github.com/pypa/setuptools_scm
-#version_scheme = "no-guess-dev"


### PR DESCRIPTION
setuptool-scm retrieves the package version from the Git tag. However, for the NGLS fork the tags do not correspond to the version, so we cannot use setuptools_scm.