### PR TITLE
PSAP is now optional for agent_ready_not_ready reports as well

### DIFF
--- a/src/shillelagh/adapters/api/nglsapi.py
+++ b/src/shillelagh/adapters/api/nglsapi.py
@@ -126,10 +126,6 @@ class NglsAPI(Adapter):
             abandoned_predicate = bounds.get('abandoned_tag')
             params['abandoned'] = abandoned_predicate.value if abandoned_predicate else 'included'
 
-        if self.table in ['agent_ready_not_ready']:
-            agency_predicate = bounds.get('agency')
-            params['psap'] = agency_predicate.value if agency_predicate else ''
-
         if self.table in ['busiest_hour']:
             call_type_predicate = bounds.get('call_type')
             if call_type_predicate:


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->
Optional PSAP for agent_ready_not_ready reports
# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
