### PR TITLE
PSAP is optional for agent_ready_not_ready report

### DIFF
--- a/src/shillelagh/backends/apsw/dialects/ngls.py
+++ b/src/shillelagh/backends/apsw/dialects/ngls.py
@@ -45,7 +45,6 @@ class NglsReports:
 
     def _text_to_string_field(self, tablename: str, col_name: str) -> String:
         if (col_name in ('interval', 'abandoned_tag') or
-            (tablename in ('agent_ready_not_ready') and col_name in ('agency')) or
                 (tablename in ('busiest_hour') and col_name in ('call_type'))):
             return String(filters=[Equal, Like, NotEqual], order=Order.ANY, exact=True)
         return String()


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
