### PR TITLE
fix: deserialize_set() must return a set in case a single string is p…

### DIFF
--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -88,7 +88,7 @@ class Adapter:
 
         This will convert a given "set(['a','b','c'])" string to the set {'a', 'b', 'c'}
         If a string is passed which does not match the /set(.*)/ regular expression, then the
-        string is simply returned as a string.
+        string is simply returned in a set with that string as single entry.
 
         Args:
             a_set_str (Any): A serialized string or None.
@@ -106,7 +106,7 @@ class Adapter:
             raise TypeError("deserialize_set(): a_set_str must be a string")
         m = re.match(r"set\((.*)\)", a_set_str)
         if not m:
-            return a_set_str
+            return set([a_set_str])
         return set(json.loads(m.group(1)))
 
     @staticmethod

--- a/src/shillelagh/adapters/base.py
+++ b/src/shillelagh/adapters/base.py
@@ -98,7 +98,7 @@ class Adapter:
 
         Returns:
             Any: The deserialized list as a set if the input was a previously serialized set.
-            Otherwise the string (or None) is simply returned.
+            A string entry is also converted to a single entry set.
         """
         if a_set_str is None:
             return None


### PR DESCRIPTION
…assed in

<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->
deserialize_set() must return a set in case a single string is passed in
<!--
# Testing instructions

What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
