### PR TITLE
Make handling of predicates dependent on superset description in NGLS…

### DIFF
--- a/src/shillelagh/adapters/api/nglsapi.py
+++ b/src/shillelagh/adapters/api/nglsapi.py
@@ -116,8 +116,8 @@ class NglsAPI(Adapter):
             (
                 x.get('column_name'),
                 x.get('type'),
-                x.get("predicate", {}).get("params", {}),
-                x.get("predicate", {}).get("default", {})
+                x.get("predicate").get("params", {}),
+                x.get("predicate").get("default", {})
             )
             for x in self.nglsreports.get_columns(self.table)
             if x.get("predicate")

--- a/src/shillelagh/adapters/api/nglsapi.py
+++ b/src/shillelagh/adapters/api/nglsapi.py
@@ -22,6 +22,7 @@ from sqlalchemy.engine.url import URL
 
 _logger = logging.getLogger(__name__)
 AVERAGE_NUMBER_OF_ROWS = 1000
+ISO_FORMAT_TIMESTAMP = "%Y-%m-%dT%H:%M:%SZ"
 
 
 class NglsAPI(Adapter):
@@ -110,26 +111,28 @@ class NglsAPI(Adapter):
         return '<pre>' + formatted_xml_string + '</pre>'
 
     def set_params(self, bounds) -> dict:
-        params = {'format': 'json'}
-
-        date_time_predicate = bounds.get('date_time')
-        if date_time_predicate:
-            params['from'] = pytz.utc.localize(date_time_predicate.start).strftime('%Y-%m-%dT%H:%M:%SZ')
-            params['to'] = pytz.utc.localize(date_time_predicate.end).strftime('%Y-%m-%dT%H:%M:%SZ')
-        else:
-            # Get latest 60 days of data.
-            params['for'] = '86400m'
-
-        if self.table not in ['agent_activity', 'text_to_911', 'location_discrepancy', 'location_queries_and_results']:
-            interval_predicate = bounds.get('interval')
-            params['interval'] = interval_predicate.value if interval_predicate else 'hour'
-
-        if self.table in ['psap_ring_time', 'psap_queue_time', 'busiest_hour', 'call_summary']:
-            abandoned_predicate = bounds.get('abandoned_tag')
-            params['abandoned'] = abandoned_predicate.value if abandoned_predicate else 'included'
-
-        if self.table in ['busiest_hour', 'call_duration']:
-            call_type_predicate = bounds.get('call_type')
-            if call_type_predicate:
-                params['terms'] = json.dumps({"localCallType": list(self.deserialize_set(call_type_predicate.value))})
-        return params
+        out_params = {'format': 'json'}
+        for (col_name, col_type, params, default) in [
+            (
+                x.get('column_name'),
+                x.get('type'),
+                x.get("predicate", {}).get("params", {}),
+                x.get("predicate", {}).get("default", {})
+            )
+            for x in self.nglsreports.get_columns(self.table)
+            if x.get("predicate")
+                ]:
+            predicate = bounds.get(col_name)
+            if predicate and params:
+                for param, key in params.items():
+                    if col_type == "TIMESTAMP":
+                        out_params[param] = pytz.utc.localize(eval(f"predicate.{key}")).strftime(ISO_FORMAT_TIMESTAMP)
+                    elif param == "terms":
+                        out_params[param] = json.dumps({f"{key}": list(self.deserialize_set(predicate.value))})
+                    else:
+                        out_params[param] = predicate.value
+            elif not predicate and default:
+                for param, value in default.items():
+                    out_params[param] = value
+        _logger.info(f"set_params({bounds}) result: {out_params}")
+        return out_params

--- a/src/shillelagh/adapters/api/nglsapi.py
+++ b/src/shillelagh/adapters/api/nglsapi.py
@@ -121,7 +121,7 @@ class NglsAPI(Adapter):
             )
             for x in self.nglsreports.get_columns(self.table)
             if x.get("predicate")
-                ]:
+        ]:
             predicate = bounds.get(col_name)
             if predicate and params:
                 for param, key in params.items():

--- a/src/shillelagh/backends/apsw/db.py
+++ b/src/shillelagh/backends/apsw/db.py
@@ -210,6 +210,7 @@ class Cursor:  # pylint: disable=too-many-instance-attributes
         """
         Execute a query using the cursor.
         """
+        _logger.info(f"Execute {operation} with parameters {parameters}")
         if not self.in_transaction and self.isolation_level:
             self._cursor.execute(f"BEGIN {self.isolation_level}")
             self.in_transaction = True

--- a/src/shillelagh/backends/apsw/dialects/ngls.py
+++ b/src/shillelagh/backends/apsw/dialects/ngls.py
@@ -18,6 +18,20 @@ from shillelagh.typing import Order
 from sqlalchemy.engine.url import URL
 from sqlalchemy.pool.base import _ConnectionFairy
 
+# Field Class from interface to Field class name
+CLASS_NAME_TO_CLASS = {
+    "DateTime": DateTime,
+    "Float": Float,
+    "Integer": Integer,
+    "String": String
+}
+# Filter name from interface to Filter class name
+FILTER_NAME_TO_FILTER = {
+    "Equal": Equal,
+    "Like": Like,
+    "NotEqual": NotEqual,
+    "Range": Range
+}
 # Default timeout for reporting API requests (in seconds)
 TIMEOUT = 30
 # Default time for an NglsReports instance before fetching again from NGLS
@@ -112,18 +126,15 @@ class NglsReports:
         if not self.columns_dicts[tablename]:
             columns_dict = {}
             for column in self.columns[tablename]:
-                col_name = column['column_name']
-                col_type = column['type']
-                if col_type == 'TEXT':
-                    columns_dict[col_name] = self._text_to_string_field(tablename, col_name)
-                elif col_type == 'INTEGER':
-                    columns_dict[col_name] = Integer()
-                elif col_type == 'FLOAT':
-                    columns_dict[col_name] = Float()
-                elif col_type == 'TIMESTAMP':
-                    columns_dict[col_name] = DateTime(filters=[Equal, Range], order=Order.ANY, exact=True)
-                else:
-                    _logger.error(f"get_columns - unhandled type: {column['type']}")
+                field = column.get('field', {})
+                class_name = field.get('class')
+                filters = field.get('filters', [])
+                filters = [FILTER_NAME_TO_FILTER[x] for x in filters] if filters else None
+                columns_dict[column['column_name']] = CLASS_NAME_TO_CLASS[class_name](
+                    filters=filters,
+                    order=field.get("order", Order.NONE),
+                    exact=field.get("exact", False)
+                )
             _logger.info(f"Created columns dictionary for {tablename}")
             self.columns_dicts[tablename] = columns_dict
         return self.columns_dicts[tablename]

--- a/src/shillelagh/backends/apsw/dialects/ngls.py
+++ b/src/shillelagh/backends/apsw/dialects/ngls.py
@@ -57,12 +57,6 @@ class NglsReports:
         self.columns_dicts = {}
         self.table_ids = {}
 
-    def _text_to_string_field(self, tablename: str, col_name: str) -> String:
-        if (col_name in ('interval', 'abandoned_tag') or
-                (tablename in ('busiest_hour', 'call_duration') and col_name in ('call_type'))):
-            return String(filters=[Equal, Like, NotEqual], order=Order.ANY, exact=True)
-        return String()
-
     def get_table_names(self):
         try:
             headers = {'X-NGLS-API-Key': self.api_key}


### PR DESCRIPTION
… reports

<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->
There is too much hard-coded stuff on predicate handling in the shillelagh layer. This PR will make that handling dependent on the description of the columns returned by the NGLS API.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
