### PR TITLE
Support retrieving agencies from the NGLS backend

### DIFF
--- a/src/shillelagh/adapters/api/nglsapi.py
+++ b/src/shillelagh/adapters/api/nglsapi.py
@@ -86,6 +86,13 @@ class NglsAPI(Adapter):
             data = [["911"], ["10-digit"], ["admin"], ["consultation"]]
         elif self.table == "seq_nrs":
             data = [[str(x).zfill(4)] for x in range(1, 1001)]
+        elif self.table == "agencies":
+            result = self.nglsreports.get_agencies()
+            if result is None:
+                raise InternalError(
+                    "Error while getting data from ngls-reporting service",
+                )
+            data = [[x.get("id")] for x in result]
         else:
             params = self.set_params(bounds)
             result = self.nglsreports.get(self.table, params)

--- a/src/shillelagh/backends/apsw/dialects/ngls.py
+++ b/src/shillelagh/backends/apsw/dialects/ngls.py
@@ -147,6 +147,17 @@ class NglsReports:
             },
         ]
         self.columns_dicts["seq_nrs"] = None
+        # add table for agencies.
+        self.table_names.append("agencies")
+        self.columns["agencies"] = [
+            {
+                "column_name": "agency",
+                "name": "Agency",
+                "type": "TEXT",
+                "field": {"class": "String"},
+            },
+        ]
+        self.columns_dicts["agencies"] = None
         _logger.info(f"table_names={self.table_names}")
 
     def has_table_name(self, tablename) -> bool:
@@ -163,6 +174,27 @@ class NglsReports:
         """Perform a GET request to the reporting service."""
         headers = {"X-NGLS-API-Key": self.api_key}
         url = self.url(tablename)
+        _logger.info(f"Get report from NGLS: GET {url} {json.dumps(params)}")
+        response = requests.get(
+            url,
+            params=params,
+            headers=headers,
+            verify=self.verify,
+            timeout=TIMEOUT,
+        )
+        if response.status_code != 200:
+            _logger.warning(f"ngls response code: {response.status_code}")
+            return None
+        return response.json()
+
+    def get_agencies(self):
+        """Perform a GET request to the reporting service."""
+        headers = {"X-NGLS-API-Key": self.api_key}
+        params = {
+            "elementType": "PSAP",
+            "gemma": True
+        }
+        url = f"https://{self.host}:{self.port}/{self.database}/v1/elements"
         _logger.info(f"Get report from NGLS: GET {url} {json.dumps(params)}")
         response = requests.get(
             url,

--- a/test/test_ngls_alchemy_dialect.py
+++ b/test/test_ngls_alchemy_dialect.py
@@ -41,15 +41,23 @@ print(inspector.get_table_names())
 
 print("get data")
 with engine.connect() as connection:
+    print("Abandoned tags")
     result = connection.execute(text("SELECT * FROM abandoned_tags"))
     for row in result:
         print(row)
+    print("Agencies")
+    result = connection.execute(text("SELECT * FROM agencies"))
+    for row in result:
+        print(row)
+    print("Call Types")
     result = connection.execute(text("SELECT * FROM call_types"))
     for row in result:
         print(row)
+    print("Intervals")
     result = connection.execute(text("SELECT * FROM intervals"))
     for row in result:
         print(row)
+    print("Test disconnect_time")
     result = connection.execute(
         text(
             "SELECT * FROM disconnect_time WHERE date_time >= '2023-04-18 00:00:00.000000' AND date_time < '2023-04-18 23:59:59.000000'",  # pylint: disable=line-too-long


### PR DESCRIPTION
<!--
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/.
Example:
  fix(gsheets): handle duration column type
  feat: new adapter for Pandas dataframes
-->

# Summary
<!--
Describe the change below, including rationale and design decisions.

You can include "Fixes #nnn" to link to an issue and automatically close it when the PR is merged.
-->

Retrieve the agencies from NGLS reporting service by sending the /elements?elementType=PSAP&gemma=true query on the NGLS API.

# Testing instructions
<!--
What steps can be taken to manually verify the changes?

Note that unit tests will fail if the code coverage drops below 100%. You can run `make test` from the
directory root to run all unit tests and check for coverage (assuming you have `pyenv` installed).
-->
